### PR TITLE
Some bad logic for auto-upgrade

### DIFF
--- a/wp-mail-bank.php
+++ b/wp-mail-bank.php
@@ -360,7 +360,7 @@ function mail_bank_plugin_update_message($args)
 
 $is_option_auto_update = get_option("mail-bank-automatic-update");
 
-if($is_option_auto_update == "" || $is_option_auto_update == "1")
+if($is_option_auto_update === "" || $is_option_auto_update == "1")
 {
 	if (!wp_next_scheduled("mail_bank_auto_update"))
 	{


### PR DESCRIPTION
You've got some bad logic around your auto update option, in which it is always upgrading regardless of settings. Here's the problematic code.

```
$is_option_auto_update = get_option("mail-bank-automatic-update");
if($is_option_auto_update == "" || $is_option_auto_update == "1")
{
     // always evaluates
}
else
{
     // never evaluates
}
```

In PHP:

```
if( false == "" )    //true
if (false === "" )  //false
```

So if your option returns the boolean false and you compare it against an empty string, the if asserts that it's true because it's not doing a strict comparison.

Thanks,

Justin
